### PR TITLE
fix: ensure UndoSnackbar renders on top of compose FAB

### DIFF
--- a/src/components/UndoSnackbar.tsx
+++ b/src/components/UndoSnackbar.tsx
@@ -83,6 +83,7 @@ function makeStyles(c: ThemePalette) {
       position: 'absolute',
       left: spacing.md,
       right: spacing.md,
+      zIndex: 50,
     },
     bar: {
       flexDirection: 'row',


### PR DESCRIPTION
Closes #16. Adds zIndex: 50 to the wrap style of UndoSnackbar to ensure it renders on top of the compose FAB (which is styled with zIndex: 40). This allows the UNDO button to be fully visible and clickable when the snackbar is shown.