### PR TITLE
fix(composer): prevent duplicate recipients from being added on done/blur action

### DIFF
--- a/src/screens/ComposeScreen.tsx
+++ b/src/screens/ComposeScreen.tsx
@@ -448,11 +448,33 @@ export default function ComposeScreen({ route, navigation }: Props) {
     const extraTo = parseRecipients(toInput);
     const extraCc = parseRecipients(ccInput);
     if (extraTo.length) {
-      setToRecipients((prev) => [...prev, ...extraTo]);
+      setToRecipients((prev) => {
+        const existing = new Set(prev.map((r) => r.email.toLowerCase()));
+        const unique: Recipient[] = [];
+        for (const r of extraTo) {
+          const emailLower = r.email.toLowerCase();
+          if (!existing.has(emailLower)) {
+            existing.add(emailLower);
+            unique.push(r);
+          }
+        }
+        return [...prev, ...unique];
+      });
       setToInput('');
     }
     if (extraCc.length) {
-      setCcRecipients((prev) => [...prev, ...extraCc]);
+      setCcRecipients((prev) => {
+        const existing = new Set(prev.map((r) => r.email.toLowerCase()));
+        const unique: Recipient[] = [];
+        for (const r of extraCc) {
+          const emailLower = r.email.toLowerCase();
+          if (!existing.has(emailLower)) {
+            existing.add(emailLower);
+            unique.push(r);
+          }
+        }
+        return [...prev, ...unique];
+      });
       setCcInput('');
     }
   };


### PR DESCRIPTION
Resolves the issue where pressing 'Done' (submitting the recipient text input) or blurring the field adds the email address twice due to concurrent event firing under React's batched state updates.

### Key Changes:
- Filters out duplicate email addresses inside the state updater function (`setToRecipients` and `setCcRecipients`) to guarantee that any redundant submissions are discarded.
- Safely processes copy-pasted comma/newline-separated recipient lists containing internal duplicates.

Fixes #21