### PR TITLE
fix(reply): send the parent's RFC msg-id in In-Reply-To, not its JMAP id

### DIFF
--- a/src/api/email.ts
+++ b/src/api/email.ts
@@ -12,6 +12,8 @@ const EMAIL_FULL_PROPERTIES = [
   ...EMAIL_LIST_PROPERTIES,
   'bodyStructure', 'textBody', 'htmlBody', 'bodyValues',
   'attachments', 'blobId', 'bcc', 'replyTo', 'sentAt',
+  // Needed to thread replies (In-Reply-To/References) — see lib/email-threading.
+  'messageId', 'inReplyTo', 'references',
 ];
 
 export async function getMailboxes(): Promise<Mailbox[]> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,6 +84,10 @@ export interface Email {
   attachments?: Attachment[];
   blobId?: string;
   bodyStructure?: BodyPart;
+  /** RFC 5322 msg-ids, bare (no angle brackets) per RFC 8621 §4.1.2.3. */
+  messageId?: string[];
+  inReplyTo?: string[];
+  references?: string[];
 }
 
 export interface MailboxRights {

--- a/src/lib/__tests__/email-threading.test.ts
+++ b/src/lib/__tests__/email-threading.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { computeReplyThreadingHeaders } from '../email-threading';
+
+describe('computeReplyThreadingHeaders', () => {
+  it('returns undefined when the parent has no msg-id', () => {
+    expect(computeReplyThreadingHeaders(undefined)).toBeUndefined();
+    expect(computeReplyThreadingHeaders({})).toBeUndefined();
+    expect(computeReplyThreadingHeaders({ messageId: [] })).toBeUndefined();
+  });
+
+  it('brackets the parent msg-id', () => {
+    expect(computeReplyThreadingHeaders({ messageId: ['abc@host'] })).toEqual({
+      inReplyTo: '<abc@host>',
+      references: '<abc@host>',
+    });
+  });
+
+  it('keeps the ancestor chain and closes it with the parent', () => {
+    expect(
+      computeReplyThreadingHeaders({
+        messageId: ['c@host'],
+        references: ['a@host', 'b@host'],
+      }),
+    ).toEqual({
+      inReplyTo: '<c@host>',
+      references: '<a@host> <b@host> <c@host>',
+    });
+  });
+
+  it('de-dupes an ancestor that is already the parent', () => {
+    expect(
+      computeReplyThreadingHeaders({ messageId: ['a@host'], references: ['a@host'] }),
+    ).toEqual({ inReplyTo: '<a@host>', references: '<a@host>' });
+  });
+
+  it('tolerates ids that already carry angle brackets', () => {
+    expect(
+      computeReplyThreadingHeaders({ messageId: ['<a@host>'], references: ['<z@host>'] }),
+    ).toEqual({ inReplyTo: '<a@host>', references: '<z@host> <a@host>' });
+  });
+});

--- a/src/lib/email-threading.ts
+++ b/src/lib/email-threading.ts
@@ -1,0 +1,51 @@
+/**
+ * RFC 5322 §3.6.4 threading headers for replies.
+ *
+ * The JMAP `Email` id (`gos2aabtux`) is a server-local handle — it is NOT the
+ * RFC msg-id. Putting it in In-Reply-To/References breaks the conversation for
+ * every downstream client, including the account's own server: Stalwart hashes
+ * the referenced msg-ids at ingest time, finds nothing that matches, and files
+ * the reply under a brand-new thread.
+ *
+ * `messageId` / `references` come back from JMAP as bare ids (no angle
+ * brackets, RFC 8621 §4.1.2.3); the wire headers need them bracketed.
+ */
+
+export interface ParentThreadingInfo {
+  messageId?: string[];
+  references?: string[];
+}
+
+export interface ReplyThreadingHeaders {
+  /** In-Reply-To header value, e.g. `<abc@host>` */
+  inReplyTo: string;
+  /** References header value: ancestors then parent, space separated */
+  references: string;
+}
+
+function stripBrackets(id: string): string {
+  return id.trim().replace(/^<|>$/g, '');
+}
+
+export function computeReplyThreadingHeaders(
+  parent: ParentThreadingInfo | undefined,
+): ReplyThreadingHeaders | undefined {
+  const parentId = parent?.messageId?.map(stripBrackets).find(Boolean);
+  if (!parentId) return undefined;
+
+  const ancestors = (parent?.references ?? []).map(stripBrackets).filter(Boolean);
+
+  // De-dupe while preserving order; the parent's id closes the chain.
+  const seen = new Set<string>();
+  const chain: string[] = [];
+  for (const id of [...ancestors, parentId]) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    chain.push(id);
+  }
+
+  return {
+    inReplyTo: `<${parentId}>`,
+    references: chain.map((id) => `<${id}>`).join(' '),
+  };
+}

--- a/src/screens/EmailThreadScreen.tsx
+++ b/src/screens/EmailThreadScreen.tsx
@@ -27,6 +27,7 @@ import {
 } from '../stores/settings-store';
 import { setEmailKeywords } from '../api/email';
 import { shareEmailEml, shareAttachment, downloadAttachment } from '../lib/email-export';
+import { computeReplyThreadingHeaders } from '../lib/email-threading';
 import { useKeywordsStore, keywordToken, type KeywordDef } from '../stores/keywords-store';
 import { useSheetDrag } from '../lib/use-sheet-drag';
 import { useLocaleStore } from '../stores/locale-store';
@@ -347,6 +348,7 @@ export default function EmailThreadScreen({ route, navigation }: Props) {
     if (!email) return;
     const from = email.from?.[0];
     if (!from && mode !== 'forward') return;
+    const threading = computeReplyThreadingHeaders(email);
     navigation.navigate('Compose', {
       mode,
       replyTo: {
@@ -356,7 +358,8 @@ export default function EmailThreadScreen({ route, navigation }: Props) {
         subject: email.subject ?? '',
         body: plainTextBody(email),
         receivedAt: email.receivedAt,
-        inReplyTo: email.id,
+        inReplyTo: threading?.inReplyTo,
+        references: threading?.references,
       },
     });
   };


### PR DESCRIPTION
## The problem

Replying puts `email.id` — the server-local JMAP handle, e.g. `gos2aabtux` — into
`In-Reply-To` and `References` (`EmailThreadScreen.tsx`, `navigateCompose`). That id is
meaningless outside the account it came from: it is not an RFC 5322 msg-id, so no client
and no server can match it against the parent's `Message-ID`.

The conversation therefore splits in two: the original message sits alone in its thread,
while the reply — and everything that answers the reply — starts a fresh one.

## Proof

Observed against a live Stalwart account (ids abbreviated):

| # | from | threadId | In-Reply-To |
|---|------|----------|-------------|
| 1 | correspondent | `btux` | — |
| 2 | reply sent from the app | **`btuz`** | `gos2aabtux` ← JMAP id of #1 |
| 3 | correspondent replies to #2 | `btuz` | `18c72125…@mail-1` |

Server side this is correct behaviour: Stalwart hashes the referenced msg-ids at ingest
(`crates/email/src/message/ingest.rs::find_thread_id`), finds no match, and files the reply
under a new thread. The webmail builds these headers correctly, so the split only happens
to conversations replied to from mobile.

## The fix

- New `src/lib/email-threading.ts`: `computeReplyThreadingHeaders()` builds the pair from the
  parent's `messageId` and `references` — bracketed, ancestors first, parent closing the
  chain, de-duped (RFC 5322 §3.6.4).
- `messageId` / `inReplyTo` / `references` added to the `Email` type and to
  `EMAIL_FULL_PROPERTIES` so they are actually fetched (JMAP returns them as bare ids,
  RFC 8621 §4.1.2.3).
- `navigateCompose` uses it instead of `email.id`.

Replies to a message whose parent has no `Message-ID` now send no threading headers at all,
rather than a header that is actively wrong.

## Tests

`src/lib/__tests__/email-threading.test.ts` — 5 cases: no msg-id, bracketing, ancestor chain,
de-dupe, ids that already carry angle brackets. `npx tsc --noEmit` clean; full suite 364 passed
(`src/stores/__tests__/auth-store.test.ts` fails to import on `main` too — pre-existing, unrelated).
